### PR TITLE
pull gym name directly from webhook

### DIFF
--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -75,7 +75,7 @@ class RaidEvent(BaseEvent):
 
         # Gym Details (currently only sent from Monocle)
         self.gym_name = check_for_none(
-            str, data.get('name'), Unknown.REGULAR).strip()
+            str, data.get('gym_name'), Unknown.REGULAR).strip()
         self.gym_description = check_for_none(
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(


### PR DESCRIPTION
RDM sends this info via webhook. So instead of using PokeAlarm's dumb and unreliable caching system, just pass the info along directly.

(Part 1 of 2 because I too am a github newb and don't know how to merge things into 1 PR)